### PR TITLE
done forgotpass otp

### DIFF
--- a/src/main/java/com/example/trua_nay_an_gi/controller/AccountController.java
+++ b/src/main/java/com/example/trua_nay_an_gi/controller/AccountController.java
@@ -77,7 +77,7 @@ public class AccountController {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
         accountOptional.get().setUserName(account.getUserName());
-        accountOptional.get().setPassword(encoder.encode(account.getPassword()));
+//        accountOptional.get().setPassword(encoder.encode(account.getPassword()));
         accountOptional.get().setEmail(account.getEmail());
         accountOptional.get().setMerchant(account.getMerchant());
         accountOptional.get().setEnabled(true);
@@ -90,7 +90,7 @@ public class AccountController {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
         accountOptional.get().setUserName(account.getUserName());
-        accountOptional.get().setPassword(encoder.encode(account.getPassword()));
+//        accountOptional.get().setPassword(encoder.encode(account.getPassword()));
         accountOptional.get().setEmail(account.getEmail());
         accountOptional.get().setUser(account.getUser());
         accountOptional.get().setEnabled(true);

--- a/src/main/java/com/example/trua_nay_an_gi/controller/EmailController.java
+++ b/src/main/java/com/example/trua_nay_an_gi/controller/EmailController.java
@@ -1,7 +1,9 @@
 package com.example.trua_nay_an_gi.controller;
 
+import com.example.trua_nay_an_gi.model.app_users.Account;
 import com.example.trua_nay_an_gi.model.app_users.AppUser;
 import com.example.trua_nay_an_gi.model.product.Mail;
+import com.example.trua_nay_an_gi.service.account.IAccountService;
 import com.example.trua_nay_an_gi.service.app_users.AppUserService;
 import com.example.trua_nay_an_gi.service.app_users.IAppUserSevice;
 import com.example.trua_nay_an_gi.service.mail.MailService;
@@ -10,6 +12,7 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
 import javax.mail.internet.MimeMessage;
@@ -17,6 +20,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
 
 @RestController
 @RequestMapping("/api/public/mail")
@@ -24,7 +28,11 @@ public class EmailController {
     @Autowired
     private IAppUserSevice userService;
     @Autowired
+    private IAccountService accountService;
+    @Autowired
     private MailService mailService;
+    @Autowired
+    PasswordEncoder encoder;
     // http://localhost:8080/mail/sender
     @PostMapping("/sender")
     public ResponseEntity<Mail> fogotPass(
@@ -65,7 +73,41 @@ public class EmailController {
         mailService.sendEmail(mail);
         return new ResponseEntity<>(mail, HttpStatus.OK);
     }
-
-
+//    http://localhost:8080/api/public/mail/chkncotp
+    @PostMapping("/chkncotp")
+    public ResponseEntity<?> checkNameCreateOTP(@RequestParam String name){
+        Optional<Account> account= Optional.ofNullable(accountService.findByName(name));
+        if(!account.isPresent()){
+            return new ResponseEntity<>(false,HttpStatus.NOT_FOUND);
+        }
+        double randomDouble = Math.random();
+        randomDouble = randomDouble * 1000000+1 ;
+        int OTP= (int) randomDouble;
+        account.get().setOtp(String.valueOf(OTP));
+        accountService.save(account.get());
+        Mail mail= new Mail();
+        mail.setMailTo(account.get().getEmail());
+        mail.setMailFrom("nguyenhuuquyet07092001@gmail.com");
+        mail.setMailSubject("Mã xác nhận OTP");
+        mail.setMailContent("Mã OTP của bạn là:"+OTP+"\nVui lòng không chia sẻ với ai\nMời nhấp link bên dưới để đến trang xác nhận OTP\nhttp://localhost:4200/forgotpass/otp");
+        mailService.sendEmail(mail);
+        return new ResponseEntity<>(true,HttpStatus.OK);
+    }
+//    http://localhost:8080/api/public/mail/confirmOtp
+    @PostMapping("/confirmOtp")
+    public ResponseEntity<?> confirmOtp(@RequestParam String otp, String name, String pass){
+        Optional<Account> account= Optional.ofNullable(accountService.findByName(name));
+        if(!account.isPresent()){
+            return new ResponseEntity<>(false,HttpStatus.NOT_FOUND);
+        }
+        if(otp.equals(account.get().getOtp())){
+            account.get().setPassword(encoder.encode(pass));
+            account.get().setOtp(null);
+            accountService.save(account.get());
+            return new ResponseEntity<>(true,HttpStatus.OK);
+        }else {
+            return new ResponseEntity<>("sai otp",HttpStatus.OK);
+        }
+    }
 
 }

--- a/src/main/java/com/example/trua_nay_an_gi/model/app_users/Account.java
+++ b/src/main/java/com/example/trua_nay_an_gi/model/app_users/Account.java
@@ -22,6 +22,7 @@ public class Account {
     private String password;
     private boolean isEnabled;
     private String email;
+    private String otp;
     @OneToOne(mappedBy = "account")
     private AppUser user;
     @OneToOne(mappedBy = "account")


### PR DESCRIPTION
Thêm trường OTP vào cho account


Khi forgotpass người dùng truyền tên tài khoản vào và server sẽ tìm acc theo name nếu k có trả về lỗi nếu có gửi otp random cho client kèm thông tin email và save otp vào acc.
Kèm theo đó chuyển người dùng sang trang nhập otp(detail :Mã otp vừa gửi về tài khoản $ có mail $ Mời nhập mã xác nhận otp )
-Khi người dùng nhập otp gửi vào sever sẽ kiểm tra nếu sai sẽ báo lỗi mười nhập lại, nếu đúng thì sẽ chuyển người dùng sang trang tạo password
-Khi người dùng nhập truyền pass vào server sẽ xác nhận và đổi pass đã mã hóa. Chuyển người dùng qua trang login